### PR TITLE
fix(valid-jsdoc): turn off `requireParamDescription` option

### DIFF
--- a/examples/good/jsdoc.js
+++ b/examples/good/jsdoc.js
@@ -1,11 +1,13 @@
 /*eslint valid-jsdoc: [2, { requireReturn: false, requireReturnDescription: false }]*/
 
 /**
- * Adds two numbers together.
- * @param {int} num1 The first number.
- * @param {int} num2 The second number.
- * @returns {int}.
+ * Evals file contents.
+ *
+ * @param {string} file The filename to eval.
+ * @param {Object} options The eval options.
+ * @param {Function} callback
+ * @returns {Object}
  */
-function foo(num1, num2) {
-    return num1 + num2;
+function fileEval(file, options, callback) {
+   /* ... */
 }

--- a/lib/common-rules.js
+++ b/lib/common-rules.js
@@ -48,7 +48,8 @@ module.exports = {
     // JSDoc
     'valid-jsdoc': ['error', {
         requireReturn: false,
-        requireReturnDescription: false
+        requireReturnDescription: false,
+        requireParamDescription: false
     }],
 
     // Whitespaces


### PR DESCRIPTION
For some parameters, such as callback or options the description is
superfluous.

Closes #33 