### PR TITLE
fix(class-methods-use-this): ignore base object methods

### DIFF
--- a/lib/es2015-rules.js
+++ b/lib/es2015-rules.js
@@ -11,6 +11,8 @@ module.exports = {
     'no-const-assign': 'error',
     'no-new-symbol': 'error',
     'require-yield': 'error',
-    'class-methods-use-this': 'error',
+    'class-methods-use-this': ['error', {
+        "exceptMethods": ['toLocaleString', 'toSource', 'toString', 'valueOf']
+    }],
     'no-useless-computed-key': 'error'
 };


### PR DESCRIPTION
For some cases need override Object methods.

Example:

```js
class A {
    toString() {
        return '[MySuperObject]';
    }
}
```

Resolved #52 