### PR TITLE
chore(package): require ESLint 4.2.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "node": ">= 4"
   },
   "peerDependencies": {
-    "eslint": ">= 3.3.0 < 5.0.0"
+    "eslint": ">= 4.2.0 < 5.0.0"
   },
   "dependencies": {},
   "devDependencies": {
-    "eslint": ">= 3.3.0 < 5.0.0"
+    "eslint": ">= 4.2.0 < 5.0.0"
   },
   "scripts": {
     "test": "eslint ."


### PR DESCRIPTION
The `getter-return` rule was introduced in ESLint 4.2.0.